### PR TITLE
Added API Guard gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 
 ## Authentication and OAuth
 
+* [API Guard](https://github.com/Gokul595/api_guard) - JWT authentication solution for Rails APIs.
 * [Authlogic](https://github.com/binarylogic/authlogic) - Authlogic is a clean, simple, and unobtrusive ruby authentication solution.
 * [Clearance](https://github.com/thoughtbot/clearance) - Small and simple email & password based authentication for Rails.
 * [Devise](https://github.com/plataformatec/devise) - A flexible authentication solution for Rails based on Warden.


### PR DESCRIPTION
## Project

**API Guard**
* https://github.com/Gokul595/api_guard
* https://rubygems.org/gems/api_guard

## What is this Ruby project?

JSON Web Token (JWT) based authentication solution with token refreshing & blacklisting for APIs built on Rails. This is built using [Ruby JWT](https://github.com/jwt/ruby-jwt) gem.

## What are the main difference between this Ruby project and similar ones?

**Below are some of the similar gems and the main differences:**

* [knock](https://github.com/nsarno/knock) 
  - This is supported only in Rails API-only application but, API Guard works in normal Rails app too.
  - This doesn't have token refreshing and blacklisting but, API Guard has.

* [Devise::JWT](https://github.com/waiting-for-dev/devise-jwt)
  - This works only with combination of devise gem but, API Guard works without devise.

Moreover, this gem was built with inspiration of devise gem to make the whole setup of API authentication simple, fast and customisable.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.